### PR TITLE
feat: implement OTP verification modal with 6-digit input (#9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-progress": "^1.1.7",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-toast": "^1.2.15",
@@ -37,6 +38,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.63.0",
+        "react-redux": "^9.2.0",
         "react-router-dom": "^7.9.3",
         "react-spinners": "^0.17.0",
         "recharts": "^3.2.1",
@@ -3847,6 +3849,38 @@
       "dependencies": {
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -12050,6 +12084,17 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web3-eth-abi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/web3-eth-accounts": {

--- a/src/app/email-verification/page.tsx
+++ b/src/app/email-verification/page.tsx
@@ -8,6 +8,7 @@ import { ResendCodeButton } from "@/components/email-verification/ResendCodeButt
 import { HelperLink } from "@/components/email-verification/HelperLink";
 import { FooterLinks } from "@/components/email-verification/FooterLinks";
 import DidntGetEmailModal from "@/components/DidntGetEmailModal";
+import ProvideOTPModal from "@/components/ProvideOTPModal";
 import Image from "next/image";
 
 const maskEmail = (email: string): string => {
@@ -30,6 +31,7 @@ export default function EmailVerificationPage({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
+  const [showOTPModal, setShowOTPModal] = useState(false);
 
   const handleOtpChange = (newOtp: string[]) => {
     setOtp(newOtp);
@@ -51,6 +53,7 @@ export default function EmailVerificationPage({
     try {
       await new Promise(resolve => setTimeout(resolve, 1000));
       console.log("Verification code:", code);
+      // On success, you might want to redirect or show success message
     } catch {
       setError("Invalid code. Please try again.");
     } finally {
@@ -74,6 +77,14 @@ export default function EmailVerificationPage({
 
   const handleHelperClick = () => {
     setShowModal(true);
+  };
+
+  const handleOTPSubmit = async (otpCode: string) => {
+    console.log('OTP submitted:', otpCode);
+    // Add your OTP verification logic here
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    // Close modal on success
+    setShowOTPModal(false);
   };
 
   return (
@@ -167,6 +178,17 @@ export default function EmailVerificationPage({
               <div>
                 <HelperLink onClick={handleHelperClick} />
               </div>
+
+              {/* Button to trigger OTP Modal (for testing/demo) */}
+              <div className="pt-4">
+                <button
+                  type="button"
+                  onClick={() => setShowOTPModal(true)}
+                  className="text-sm text-gray-500 hover:text-gray-700 underline"
+                >
+                  Open OTP Modal
+                </button>
+              </div>
             </form>
 
             <div className="mt-8 lg:mt-12">
@@ -176,9 +198,17 @@ export default function EmailVerificationPage({
         </div>
       </div>
 
+      {/* Didn't Get Email Modal */}
       <DidntGetEmailModal
         isOpen={showModal}
         onClose={() => setShowModal(false)}
+      />
+
+      {/* Provide OTP Modal */}
+      <ProvideOTPModal
+        isOpen={showOTPModal}
+        onClose={() => setShowOTPModal(false)}
+        onSubmit={handleOTPSubmit}
       />
     </div>
   );

--- a/src/components/ProvideOTPModal.tsx
+++ b/src/components/ProvideOTPModal.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React, { useState, useRef } from 'react';
+
+interface ProvideOTPModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSubmit: (otp: string) => Promise<void>;
+}
+
+const ProvideOTPModal: React.FC<ProvideOTPModalProps> = ({
+    isOpen,
+    onClose,
+    onSubmit
+}) => {
+    const [otp, setOtp] = useState<string[]>(Array(6).fill(''));
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+    React.useEffect(() => {
+        if (!isOpen) return;
+
+        const handleEsc = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', handleEsc);
+
+        if (isOpen) {
+            setTimeout(() => inputRefs.current[0]?.focus(), 100);
+        }
+
+        return () => window.removeEventListener('keydown', handleEsc);
+    }, [isOpen, onClose]);
+
+    const handleChange = (inputValue: string, index: number) => {
+        if (/^[0-9]?$/.test(inputValue)) {
+            const newOtp = [...otp];
+            newOtp[index] = inputValue;
+            setOtp(newOtp);
+
+            if (inputValue && index < 5) {
+                inputRefs.current[index + 1]?.focus();
+            }
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+        if (e.key === 'Backspace' && !otp[index] && index > 0) {
+            inputRefs.current[index - 1]?.focus();
+        }
+    };
+
+    const handlePaste = (e: React.ClipboardEvent) => {
+        e.preventDefault();
+        const pasteData = e.clipboardData.getData('text');
+        const digits = pasteData.replace(/\D/g, '').slice(0, 6).split('');
+
+        if (digits.length > 0) {
+            const newOtp = [...otp];
+            digits.forEach((digit, index) => {
+                if (index < 6) {
+                    newOtp[index] = digit;
+                }
+            });
+            setOtp(newOtp);
+
+            const nextIndex = Math.min(digits.length, 5);
+            inputRefs.current[nextIndex]?.focus();
+        }
+    };
+
+    const handleSubmit = async () => {
+        const otpString = otp.join('');
+        if (otpString.length !== 6) return;
+
+        setIsSubmitting(true);
+        try {
+            await onSubmit(otpString);
+            setOtp(Array(6).fill(''));
+        } catch (error) {
+            console.error('OTP submission failed:', error);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    if (!isOpen) return null;
+
+    const isComplete = otp.every(digit => digit !== '');
+
+    return (
+        <div
+            className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-gray-900/30 backdrop-blur-[2px]"
+            onClick={onClose}
+            role="dialog"
+            aria-modal="true"
+        >
+            <div
+                className="relative w-full max-w-sm bg-white rounded-2xl p-6 md:p-8 shadow-2xl"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <button
+                    onClick={onClose}
+                    className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 transition-colors"
+                    aria-label="Close modal"
+                >
+                    <svg
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                    >
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                </button>
+
+                <h2 className="text-xl md:text-2xl font-bold text-center text-gray-900 mb-2">
+                    Provide OTP
+                </h2>
+
+                <p className="text-sm text-center text-gray-600 mb-6">
+                    Enter the verification code sent to your email address
+                </p>
+
+                <div className="flex justify-center gap-2 mb-6">
+                    {otp.map((digit, index) => (
+                        <input
+                            key={index}
+                            ref={(el) => { inputRefs.current[index] = el; }}
+                            type="text"
+                            inputMode="numeric"
+                            maxLength={1}
+                            value={digit}
+                            onChange={(e) => handleChange(e.target.value, index)}
+                            onKeyDown={(e) => handleKeyDown(e, index)}
+                            onPaste={handlePaste}
+                            className="w-12 h-14 text-center text-xl font-semibold text-gray-900 bg-white border-2 border-gray-300 rounded-lg focus:outline-none focus:border-[#5E2A8C] focus:ring-2 focus:ring-[#5E2A8C]/20 transition-all"
+                            aria-label={`Digit ${index + 1}`}
+                        />
+                    ))}
+                </div>
+
+                <button
+                    onClick={handleSubmit}
+                    disabled={!isComplete || isSubmitting}
+                    className="w-full bg-[#5E2A8C] hover:bg-[#4E1F6C] disabled:bg-gray-300 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                >
+                    {isSubmitting ? 'Verifying...' : 'Submit'}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default ProvideOTPModal;


### PR DESCRIPTION
- Create ProvideOTPModal component with 6 individual input boxes
- Auto-focus on first input field when modal opens
- Auto-advance to next field on digit entry
- Backspace navigation to previous field
- Paste support for 6-digit codes
- Number-only validation
- Submit button with loading state
- Semi-transparent backdrop keeping page content visible
- Fully responsive for desktop and mobile views
- Match Figma design specifications

close #97 

test prove 

<img width="1334" height="743" alt="Screenshot 2025-10-02 235206" src="https://github.com/user-attachments/assets/c3db14bd-0181-43d4-9550-4dc6b1d3f035" />
<img width="726" height="751" alt="Screenshot 2025-10-02 235229" src="https://github.com/user-attachments/assets/7510b47f-6135-4bd6-a8e2-683e298cc0c6" />
