### PR TITLE
feat(auth): implement Apple OAuth Sign-In and refactor provisioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@tailwindcss/postcss": "^4",
         "@types/bcryptjs": "^2.4.6",
         "@types/dom-to-image": "^2.6.7",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.19.17",
         "@types/pg": "^8.16.0",
         "@types/react": "^19.1.13",
@@ -6755,6 +6756,24 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },

--- a/src/api/services/apple-oauth.service.spec.ts
+++ b/src/api/services/apple-oauth.service.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as jose from "jose";
+import { AppleOAuthService } from "./apple-oauth.service";
+import {
+  InvalidTokenError,
+  TokenExpiredError,
+  AudienceMismatchError,
+  IssuerMismatchError,
+} from "../utils/errors";
+
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(),
+  jwtVerify: vi.fn(),
+  errors: {
+    JWTExpired: class extends Error {
+      constructor(message: string) {
+        super(message);
+      }
+    },
+    JWTClaimValidationFailed: class extends Error {
+      claim: string;
+      constructor(message: string, _payload: any, claim: string) {
+        super(message);
+        this.claim = claim;
+      }
+    },
+  },
+}));
+
+describe("AppleOAuthService", () => {
+  const mockIdToken = "mock.id.token";
+  const mockClientId = "com.example.app";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.APPLE_CLIENT_ID = mockClientId;
+    (jose.createRemoteJWKSet as any).mockReturnValue(() => {});
+  });
+
+  it("should verify a valid token and return user info", async () => {
+    const mockPayload = {
+      sub: "apple-user-123",
+      email: "user@example.com",
+    };
+
+    (jose.jwtVerify as any).mockResolvedValue({ payload: mockPayload });
+
+    const result = await AppleOAuthService.verifyIdToken(mockIdToken);
+
+    expect(result).toEqual({
+      email: "user@example.com",
+      firstName: "",
+      lastName: "",
+      oauthId: "apple-user-123",
+    });
+    expect(jose.jwtVerify).toHaveBeenCalledWith(
+      mockIdToken,
+      expect.any(Function),
+      {
+        issuer: "https://appleid.apple.com",
+        audience: mockClientId,
+      },
+    );
+  });
+
+  it("should throw TokenExpiredError when token is expired", async () => {
+    (jose.jwtVerify as any).mockRejectedValue(
+      new jose.errors.JWTExpired("Token has expired", {} as any),
+    );
+
+    await expect(AppleOAuthService.verifyIdToken(mockIdToken)).rejects.toThrow(
+      TokenExpiredError,
+    );
+  });
+
+  it("should throw AudienceMismatchError when audience mismatch", async () => {
+    (jose.jwtVerify as any).mockRejectedValue(
+      new jose.errors.JWTClaimValidationFailed(
+        "aud mismatch",
+        {} as any,
+        "aud",
+      ),
+    );
+
+    await expect(AppleOAuthService.verifyIdToken(mockIdToken)).rejects.toThrow(
+      AudienceMismatchError,
+    );
+  });
+
+  it("should throw IssuerMismatchError when issuer mismatch", async () => {
+    (jose.jwtVerify as any).mockRejectedValue(
+      new jose.errors.JWTClaimValidationFailed(
+        "iss mismatch",
+        {} as any,
+        "iss",
+      ),
+    );
+
+    await expect(AppleOAuthService.verifyIdToken(mockIdToken)).rejects.toThrow(
+      IssuerMismatchError,
+    );
+  });
+
+  it("should throw InvalidTokenError when sub or email is missing", async () => {
+    (jose.jwtVerify as any).mockResolvedValue({ payload: { sub: "123" } }); // Missing email
+
+    await expect(AppleOAuthService.verifyIdToken(mockIdToken)).rejects.toThrow(
+      InvalidTokenError,
+    );
+  });
+
+  it("should throw error if APPLE_CLIENT_ID is not configured", async () => {
+    delete process.env.APPLE_CLIENT_ID;
+
+    await expect(AppleOAuthService.verifyIdToken(mockIdToken)).rejects.toThrow(
+      "APPLE_CLIENT_ID is not configured",
+    );
+  });
+});

--- a/src/api/services/apple-oauth.service.ts
+++ b/src/api/services/apple-oauth.service.ts
@@ -1,0 +1,66 @@
+import * as jose from "jose";
+import {
+  InvalidTokenError,
+  TokenExpiredError,
+  AudienceMismatchError,
+  IssuerMismatchError,
+} from "../utils/errors";
+import { OAuthUserInfo } from "./oauth-user-provisioning.service";
+
+export class AppleOAuthService {
+  private static APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys";
+  private static APPLE_ISSUER = "https://appleid.apple.com";
+
+  static async verifyIdToken(idToken: string): Promise<OAuthUserInfo> {
+    const clientId = process.env.APPLE_CLIENT_ID;
+
+    if (!clientId) {
+      throw new Error("APPLE_CLIENT_ID is not configured");
+    }
+
+    try {
+      // Create a Remote Key Set from Apple's public keys
+      const JWKS = jose.createRemoteJWKSet(new URL(this.APPLE_KEYS_URL));
+
+      // Verify the JWT
+      const { payload } = await jose.jwtVerify(idToken, JWKS, {
+        issuer: this.APPLE_ISSUER,
+        audience: clientId,
+      });
+
+      if (!payload.sub || !payload.email) {
+        throw new InvalidTokenError(
+          "Apple token missing required claims (sub, email)",
+        );
+      }
+
+      // Extract info
+      return {
+        email: payload.email as string,
+        firstName: "", // Apple only provides this on first sign-in, handled in route
+        lastName: "", // Apple only provides this on first sign-in, handled in route
+        oauthId: payload.sub,
+      };
+    } catch (error) {
+      if (error instanceof jose.errors.JWTExpired) {
+        throw new TokenExpiredError("Apple token has expired");
+      }
+      if (error instanceof jose.errors.JWTClaimValidationFailed) {
+        if (error.claim === "aud") {
+          throw new AudienceMismatchError("Apple token audience mismatch");
+        }
+        if (error.claim === "iss") {
+          throw new IssuerMismatchError("Apple token issuer mismatch");
+        }
+      }
+
+      console.error("[Apple OAuth Error]", error);
+      if (error instanceof Error) {
+        throw new InvalidTokenError(
+          `Failed to verify Apple token: ${error.message}`,
+        );
+      }
+      throw new InvalidTokenError("Failed to verify Apple token");
+    }
+  }
+}

--- a/src/api/services/google-oauth.service.ts
+++ b/src/api/services/google-oauth.service.ts
@@ -1,100 +1,97 @@
 import { OAuth2Client } from "google-auth-library";
 import {
-    InvalidTokenError,
-    TokenExpiredError,
-    AudienceMismatchError,
-    IssuerMismatchError,
+  InvalidTokenError,
+  TokenExpiredError,
+  AudienceMismatchError,
+  IssuerMismatchError,
 } from "../utils/errors";
-
-export interface GoogleUserInfo {
-    email: string;
-    firstName: string;
-    lastName: string;
-    oauthId: string;
-}
+import { OAuthUserInfo } from "./oauth-user-provisioning.service";
 
 export class GoogleOAuthService {
-    private static client: OAuth2Client;
+  private static client: OAuth2Client;
 
-    private static getClient(): OAuth2Client {
-        if (!this.client) {
-            const clientId = process.env.GOOGLE_CLIENT_ID;
-            if (!clientId) {
-                throw new Error("GOOGLE_CLIENT_ID is not configured");
-            }
-            this.client = new OAuth2Client(clientId);
-        }
-        return this.client;
+  private static getClient(): OAuth2Client {
+    if (!this.client) {
+      const clientId = process.env.GOOGLE_CLIENT_ID;
+      if (!clientId) {
+        throw new Error("GOOGLE_CLIENT_ID is not configured");
+      }
+      this.client = new OAuth2Client(clientId);
+    }
+    return this.client;
+  }
+
+  static async verifyIdToken(idToken: string): Promise<OAuthUserInfo> {
+    const client = this.getClient();
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+
+    if (!clientId) {
+      throw new Error("GOOGLE_CLIENT_ID is not configured");
     }
 
-    static async verifyIdToken(idToken: string): Promise<GoogleUserInfo> {
-        const client = this.getClient();
-        const clientId = process.env.GOOGLE_CLIENT_ID;
+    try {
+      const ticket = await client.verifyIdToken({
+        idToken,
+        audience: clientId,
+      });
 
-        if (!clientId) {
-            throw new Error("GOOGLE_CLIENT_ID is not configured");
+      const payload = ticket.getPayload();
+
+      if (!payload) {
+        throw new InvalidTokenError("Token payload is empty");
+      }
+
+      if (payload.aud !== clientId) {
+        throw new AudienceMismatchError(
+          "Token audience does not match GOOGLE_CLIENT_ID",
+        );
+      }
+
+      const validIssuers = [
+        "accounts.google.com",
+        "https://accounts.google.com",
+      ];
+      if (!validIssuers.includes(payload.iss)) {
+        throw new IssuerMismatchError("Token issuer is not Google");
+      }
+
+      if (!payload.email || !payload.sub) {
+        throw new InvalidTokenError("Token missing required fields");
+      }
+
+      return this.extractUserInfo(payload);
+    } catch (error) {
+      if (
+        error instanceof AudienceMismatchError ||
+        error instanceof IssuerMismatchError ||
+        error instanceof InvalidTokenError
+      ) {
+        throw error;
+      }
+
+      if (error instanceof Error) {
+        if (error.message.includes("Token used too late")) {
+          throw new TokenExpiredError("Google token has expired");
         }
 
-        try {
-            const ticket = await client.verifyIdToken({
-                idToken,
-                audience: clientId,
-            });
+        console.error("[Google OAuth Error]", error.message);
+        throw new InvalidTokenError("Failed to verify Google token");
+      }
 
-            const payload = ticket.getPayload();
-
-            if (!payload) {
-                throw new InvalidTokenError("Token payload is empty");
-            }
-
-            if (payload.aud !== clientId) {
-                throw new AudienceMismatchError(
-                    "Token audience does not match GOOGLE_CLIENT_ID"
-                );
-            }
-
-            const validIssuers = ["accounts.google.com", "https://accounts.google.com"];
-            if (!validIssuers.includes(payload.iss)) {
-                throw new IssuerMismatchError("Token issuer is not Google");
-            }
-
-            if (!payload.email || !payload.sub) {
-                throw new InvalidTokenError("Token missing required fields");
-            }
-
-            return this.extractUserInfo(payload);
-        } catch (error) {
-            if (
-                error instanceof AudienceMismatchError ||
-                error instanceof IssuerMismatchError ||
-                error instanceof InvalidTokenError
-            ) {
-                throw error;
-            }
-
-            if (error instanceof Error) {
-                if (error.message.includes("Token used too late")) {
-                    throw new TokenExpiredError("Google token has expired");
-                }
-
-                console.error("[Google OAuth Error]", error.message);
-                throw new InvalidTokenError("Failed to verify Google token");
-            }
-
-            throw new InvalidTokenError("Failed to verify Google token");
-        }
+      throw new InvalidTokenError("Failed to verify Google token");
     }
+  }
 
-    private static extractUserInfo(payload: any): GoogleUserInfo {
-        const nameParts = (payload.name || "").split(" ");
-        const firstName = nameParts[0] || payload.given_name || "";
-        const lastName = nameParts.slice(1).join(" ") || payload.family_name || "";
+  private static extractUserInfo(payload: any): GoogleUserInfo {
+    const nameParts = (payload.name || "").split(" ");
+    const firstName = nameParts[0] || payload.given_name || "";
+    const lastName = nameParts.slice(1).join(" ") || payload.family_name || "";
 
-        return {
-            email: payload.email,
-            firstName: firstName || "User",
-            lastName: lastName || "",
-            oauthId: payload.sub,
-        };
-    }
+    return {
+      email: payload.email,
+      firstName: firstName || "User",
+      lastName: lastName || "",
+      oauthId: payload.sub,
+    };
+  }
 }

--- a/src/api/services/oauth-user-provisioning.service.ts
+++ b/src/api/services/oauth-user-provisioning.service.ts
@@ -1,109 +1,117 @@
 import { db, users } from "../db";
 import { eq } from "drizzle-orm";
-import { GoogleUserInfo } from "./google-oauth.service";
+export interface OAuthUserInfo {
+  email: string;
+  firstName: string;
+  lastName: string;
+  oauthId: string;
+}
 
 export class OAuthUserProvisioningService {
-    static async provisionUser(googleUserInfo: GoogleUserInfo) {
-        const { email, firstName, lastName, oauthId } = googleUserInfo;
+  static async provisionUser(
+    oauthUserInfo: OAuthUserInfo,
+    provider: "google" | "apple",
+  ) {
+    const { email, firstName, lastName, oauthId } = oauthUserInfo;
 
-        let user = await this.findByOAuthId(oauthId);
+    let user = await this.findByOAuthId(oauthId);
 
-        if (user) {
-            await this.updateLastLoginAt(user.id);
-            return user;
-        }
-
-        user = await this.findByEmail(email);
-
-        if (user) {
-            const updatedUser = await this.updateOAuthInfo(user.id, {
-                oauthProvider: "google",
-                oauthId,
-            });
-            await this.updateLastLoginAt(updatedUser.id);
-            return updatedUser;
-        }
-
-        const newUser = await this.createOAuthUser({
-            email,
-            firstName,
-            lastName,
-            oauthProvider: "google",
-            oauthId,
-        });
-
-        return newUser;
+    if (user) {
+      await this.updateLastLoginAt(user.id);
+      return user;
     }
 
-    static async findByOAuthId(oauthId: string) {
-        const [user] = await db
-            .select()
-            .from(users)
-            .where(eq(users.oauthId, oauthId))
-            .limit(1);
+    user = await this.findByEmail(email);
 
-        return user || null;
+    if (user) {
+      const updatedUser = await this.updateOAuthInfo(user.id, {
+        oauthProvider: provider,
+        oauthId,
+      });
+      await this.updateLastLoginAt(updatedUser.id);
+      return updatedUser;
     }
 
-    static async findByEmail(email: string) {
-        const [user] = await db
-            .select()
-            .from(users)
-            .where(eq(users.email, email))
-            .limit(1);
+    const newUser = await this.createOAuthUser({
+      email,
+      firstName,
+      lastName,
+      oauthProvider: provider,
+      oauthId,
+    });
 
-        return user || null;
-    }
+    return newUser;
+  }
 
-    static async updateOAuthInfo(
-        userId: string,
-        oauthInfo: { oauthProvider: string; oauthId: string }
-    ) {
-        const [updatedUser] = await db
-            .update(users)
-            .set({
-                oauthProvider: oauthInfo.oauthProvider,
-                oauthId: oauthInfo.oauthId,
-                status: "active",
-                updatedAt: new Date(),
-            })
-            .where(eq(users.id, userId))
-            .returning();
+  static async findByOAuthId(oauthId: string) {
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.oauthId, oauthId))
+      .limit(1);
 
-        return updatedUser;
-    }
+    return user || null;
+  }
 
-    static async updateLastLoginAt(userId: string) {
-        await db
-            .update(users)
-            .set({
-                lastLoginAt: new Date(),
-                updatedAt: new Date(),
-            })
-            .where(eq(users.id, userId));
-    }
+  static async findByEmail(email: string) {
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
 
-    private static async createOAuthUser(data: {
-        email: string;
-        firstName: string;
-        lastName: string;
-        oauthProvider: string;
-        oauthId: string;
-    }) {
-        const [user] = await db
-            .insert(users)
-            .values({
-                firstName: data.firstName,
-                lastName: data.lastName,
-                email: data.email,
-                oauthProvider: data.oauthProvider,
-                oauthId: data.oauthId,
-                passwordHash: null,
-                status: "active",
-                lastLoginAt: new Date(),
-            })
-            .returning();
+    return user || null;
+  }
 
-        return user;
-    }
+  static async updateOAuthInfo(
+    userId: string,
+    oauthInfo: { oauthProvider: string; oauthId: string },
+  ) {
+    const [updatedUser] = await db
+      .update(users)
+      .set({
+        oauthProvider: oauthInfo.oauthProvider,
+        oauthId: oauthInfo.oauthId,
+        status: "active",
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId))
+      .returning();
+
+    return updatedUser;
+  }
+
+  static async updateLastLoginAt(userId: string) {
+    await db
+      .update(users)
+      .set({
+        lastLoginAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId));
+  }
+
+  private static async createOAuthUser(data: {
+    email: string;
+    firstName: string;
+    lastName: string;
+    oauthProvider: string;
+    oauthId: string;
+  }) {
+    const [user] = await db
+      .insert(users)
+      .values({
+        firstName: data.firstName,
+        lastName: data.lastName,
+        email: data.email,
+        oauthProvider: data.oauthProvider,
+        oauthId: data.oauthId,
+        passwordHash: null,
+        status: "active",
+        lastLoginAt: new Date(),
+      })
+      .returning();
+
+    return user;
+  }
 }

--- a/src/api/validations/auth.schema.ts
+++ b/src/api/validations/auth.schema.ts
@@ -11,7 +11,7 @@ export type RegisterInput = z.infer<typeof RegisterSchema>;
 export const ResendOTPSchema = z.object({
   email: z.preprocess(
     (val) => (typeof val === "string" ? val.trim().toLowerCase() : val),
-    z.string().email("Invalid email format")
+    z.string().email("Invalid email format"),
   ),
 });
 
@@ -22,3 +22,20 @@ export const GoogleOAuthSchema = z.object({
 });
 
 export type GoogleOAuthInput = z.infer<typeof GoogleOAuthSchema>;
+
+export const AppleOAuthSchema = z.object({
+  idToken: z.string().min(1, "ID token is required"),
+  user: z
+    .object({
+      name: z
+        .object({
+          firstName: z.string().optional(),
+          lastName: z.string().optional(),
+        })
+        .optional(),
+      email: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type AppleOAuthInput = z.infer<typeof AppleOAuthSchema>;

--- a/src/app/api/auth/apple/route.ts
+++ b/src/app/api/auth/apple/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from "next/server";
+import { AppleOAuthSchema } from "@/api/validations/auth.schema";
+import { AppleOAuthService } from "@/api/services/apple-oauth.service";
+import { OAuthUserProvisioningService } from "@/api/services/oauth-user-provisioning.service";
+import { JWTService } from "@/api/services/jwt.service";
+import { SessionService } from "@/api/services/session.service";
+import { ApiResponse } from "@/api/utils/api-response";
+import { AppError } from "@/api/utils/errors";
+import { ZodError } from "zod";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const validatedData = AppleOAuthSchema.parse(body);
+
+    console.log("[Apple OAuth] Verifying ID token");
+    const oauthUserInfo = await AppleOAuthService.verifyIdToken(
+      validatedData.idToken,
+    );
+
+    // Apple only provides user data (name and email) on first sign-in.
+    // If provided, we merge it with the verified info.
+    if (validatedData.user) {
+      if (validatedData.user.name) {
+        oauthUserInfo.firstName =
+          validatedData.user.name.firstName || oauthUserInfo.firstName;
+        oauthUserInfo.lastName =
+          validatedData.user.name.lastName || oauthUserInfo.lastName;
+      }
+      // Email should already be in the token, but we can verify/update if needed
+      if (validatedData.user.email) {
+        oauthUserInfo.email = validatedData.user.email;
+      }
+    }
+
+    console.log("[Apple OAuth] Provisioning user:", oauthUserInfo.email);
+    const user = await OAuthUserProvisioningService.provisionUser(
+      oauthUserInfo,
+      "apple",
+    );
+
+    const jwtPayload = {
+      userId: user.id,
+      email: user.email,
+    };
+
+    console.log("[Apple OAuth] Generating tokens");
+    const accessToken = JWTService.generateAccessToken(jwtPayload);
+    const refreshToken = JWTService.generateRefreshToken(jwtPayload);
+
+    console.log("[Apple OAuth] Creating session");
+    await SessionService.createSession(user.id, refreshToken);
+
+    const response = ApiResponse.success(
+      {
+        accessToken,
+        refreshToken,
+        user: {
+          id: user.id,
+          email: user.email,
+          firstName: user.firstName,
+          lastName: user.lastName,
+        },
+      },
+      "Authentication successful",
+      200,
+    );
+
+    response.cookies.set("refreshToken", refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 7,
+      path: "/",
+    });
+
+    console.log("[Apple OAuth] Authentication successful for:", user.email);
+    return response;
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const fieldErrors: Record<string, string> = {};
+      error.issues.forEach((err) => {
+        if (err.path[0]) {
+          fieldErrors[err.path[0].toString()] = err.message;
+        }
+      });
+      console.error("[Apple OAuth] Validation error:", fieldErrors);
+      return ApiResponse.error("Validation failed", 400, { fieldErrors });
+    }
+
+    if (error instanceof AppError) {
+      console.error(
+        `[Apple OAuth] ${error.name}:`,
+        error.message,
+        error.statusCode,
+      );
+      return ApiResponse.error(error.message, error.statusCode, error.errors);
+    }
+
+    console.error("[Apple OAuth] Unexpected error:", error);
+    return ApiResponse.error("Internal server error", 500);
+  }
+}


### PR DESCRIPTION
Implemented Apple Sign-In support to allow users to authenticate using their Apple ID. This PR also includes a refactor of the user provisioning layer to support multiple OAuth providers.

### ✨ Key Changes

#### New Services
- **AppleOAuthService**: Created a new service using `jose` to securely verify Apple ID tokens
  - Signature verification
  - Issuer validation
  - Audience verification

#### Refactored Components
- **OAuthUserProvisioningService**: Refactored the provisioning logic to be provider-agnostic
  - Enables seamless integration for both Google and Apple users
  - Centralized user creation/matching logic

#### API Endpoints
- **New Route**: `POST /api/auth/apple`
  - Handles `{ idToken, user }` payload
  - Manages Apple's unique first-time sign-in data (name/email)
  - Consistent with existing OAuth flow patterns

#### Validation & Type Safety
- Added Zod schemas for Apple OAuth request body validation
- Type-safe request/response handling

### ✅ Testing & Verification

#### Test Coverage
- ✅ Comprehensive unit tests for Apple token verification
- ✅ Project-wide integration tests (all 140 tests passing)

#### Security & Edge Cases
- ✅ Token expiration handling
- ✅ Audience mismatch error handling
- ✅ User creation/matching logic by `oauthId` (Apple's `sub`)
- ✅ Email-based user matching
- ✅ JWT session generation consistency
- ✅ HTTP-only cookie setting verification

closes #192 

<img width="446" height="282" alt="Screenshot 2026-01-31 090818" src="https://github.com/user-attachments/assets/c1ad089d-23a9-447a-917e-c060e371e0d3" />
