### PR TITLE
feat: optimize onboarding status API with parallel queries and step details

### DIFF
--- a/src/app/api/dashboard/onboarding/route.test.ts
+++ b/src/app/api/dashboard/onboarding/route.test.ts
@@ -8,6 +8,37 @@ import { UnauthorizedError } from "@/api/utils/errors";
 vi.mock("@/api/services/onboarding.service");
 vi.mock("@/api/utils/auth");
 
+const buildMockStatus = (overrides: {
+  emailVerified?: boolean;
+  companyInfoProvided?: boolean;
+  kybVerified?: boolean;
+  walletFunded?: boolean;
+} = {}) => {
+  const emailVerified = overrides.emailVerified ?? false;
+  const companyInfoProvided = overrides.companyInfoProvided ?? false;
+  const kybVerified = overrides.kybVerified ?? false;
+  const walletFunded = overrides.walletFunded ?? false;
+
+  const steps = [
+    { key: "emailVerified", label: "Email Verification", completed: emailVerified },
+    { key: "companyInfoProvided", label: "Company Profile", completed: companyInfoProvided },
+    { key: "kybVerified", label: "KYB Verification", completed: kybVerified },
+    { key: "walletFunded", label: "Wallet Funding", completed: walletFunded },
+  ];
+  const completedSteps = steps.filter((s) => s.completed).length;
+
+  return {
+    emailVerified,
+    companyInfoProvided,
+    kybVerified,
+    walletFunded,
+    completedSteps,
+    totalSteps: 4,
+    progressPercentage: (completedSteps / 4) * 100,
+    steps,
+  };
+};
+
 describe("GET /api/dashboard/onboarding", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -19,13 +50,7 @@ describe("GET /api/dashboard/onboarding", () => {
 
   it("should return 25% progress when only email is verified", async () => {
     const mockUser = { userId: "user-123" };
-    const mockStatus = {
-      emailVerified: true,
-      companyInfoProvided: false,
-      kybVerified: false,
-      walletFunded: false,
-      progressPercentage: 25,
-    };
+    const mockStatus = buildMockStatus({ emailVerified: true });
 
     vi.mocked(AuthUtils.authenticateRequest).mockResolvedValue(mockUser as any);
     vi.mocked(OnboardingService.getOnboardingStatus).mockResolvedValue(mockStatus);
@@ -41,19 +66,26 @@ describe("GET /api/dashboard/onboarding", () => {
     expect(data.data.companyInfoProvided).toBe(false);
     expect(data.data.kybVerified).toBe(false);
     expect(data.data.walletFunded).toBe(false);
+    expect(data.data.completedSteps).toBe(1);
+    expect(data.data.totalSteps).toBe(4);
     expect(data.data.progressPercentage).toBe(25);
+    expect(data.data.steps).toHaveLength(4);
+    expect(data.data.steps[0]).toEqual({
+      key: "emailVerified",
+      label: "Email Verification",
+      completed: true,
+    });
     expect(OnboardingService.getOnboardingStatus).toBeCalledWith("user-123");
   });
 
   it("should return 100% progress when all steps are complete", async () => {
     const mockUser = { userId: "user-123" };
-    const mockStatus = {
+    const mockStatus = buildMockStatus({
       emailVerified: true,
       companyInfoProvided: true,
       kybVerified: true,
       walletFunded: true,
-      progressPercentage: 100,
-    };
+    });
 
     vi.mocked(AuthUtils.authenticateRequest).mockResolvedValue(mockUser as any);
     vi.mocked(OnboardingService.getOnboardingStatus).mockResolvedValue(mockStatus);
@@ -64,22 +96,14 @@ describe("GET /api/dashboard/onboarding", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.success).toBe(true);
+    expect(data.data.completedSteps).toBe(4);
     expect(data.data.progressPercentage).toBe(100);
-    expect(data.data.emailVerified).toBe(true);
-    expect(data.data.companyInfoProvided).toBe(true);
-    expect(data.data.kybVerified).toBe(true);
-    expect(data.data.walletFunded).toBe(true);
+    expect(data.data.steps.every((s: any) => s.completed)).toBe(true);
   });
 
   it("should return 0% progress when no steps are complete", async () => {
     const mockUser = { userId: "user-123" };
-    const mockStatus = {
-      emailVerified: false,
-      companyInfoProvided: false,
-      kybVerified: false,
-      walletFunded: false,
-      progressPercentage: 0,
-    };
+    const mockStatus = buildMockStatus();
 
     vi.mocked(AuthUtils.authenticateRequest).mockResolvedValue(mockUser as any);
     vi.mocked(OnboardingService.getOnboardingStatus).mockResolvedValue(mockStatus);
@@ -90,7 +114,28 @@ describe("GET /api/dashboard/onboarding", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.success).toBe(true);
+    expect(data.data.completedSteps).toBe(0);
     expect(data.data.progressPercentage).toBe(0);
+    expect(data.data.steps.every((s: any) => !s.completed)).toBe(true);
+  });
+
+  it("should return 50% progress when two steps are complete", async () => {
+    const mockUser = { userId: "user-123" };
+    const mockStatus = buildMockStatus({
+      emailVerified: true,
+      companyInfoProvided: true,
+    });
+
+    vi.mocked(AuthUtils.authenticateRequest).mockResolvedValue(mockUser as any);
+    vi.mocked(OnboardingService.getOnboardingStatus).mockResolvedValue(mockStatus);
+
+    const req = createMockRequest();
+    const response = await GET(req);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.data.completedSteps).toBe(2);
+    expect(data.data.progressPercentage).toBe(50);
   });
 
   it("should return 401 for unauthorized access", async () => {

--- a/src/app/api/dashboard/onboarding/route.ts
+++ b/src/app/api/dashboard/onboarding/route.ts
@@ -29,8 +29,23 @@ import { OnboardingService } from "@/api/services/onboarding.service";
  *                   type: boolean
  *                 walletFunded:
  *                   type: boolean
+ *                 completedSteps:
+ *                   type: number
+ *                 totalSteps:
+ *                   type: number
  *                 progressPercentage:
  *                   type: number
+ *                 steps:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       key:
+ *                         type: string
+ *                       label:
+ *                         type: string
+ *                       completed:
+ *                         type: boolean
  *       401:
  *         description: Unauthorized
  *       404:


### PR DESCRIPTION
## Summary
- Optimize `GET /api/dashboard/onboarding` by running company profile, KYB, and wallet DB queries concurrently with `Promise.all` instead of sequentially
- Add `completedSteps`, `totalSteps`, and `steps` array to the response for powering the dashboard progress tracker and circular graph
- Add 50% progress test case for better coverage

Closes #231

## Test plan
- [ ] Verify `npx tsc --noEmit` passes with no errors in onboarding files
- [ ] Run `npx vitest run src/app/api/dashboard/onboarding` — all 7 tests pass
- [ ] Manual test: `GET /api/dashboard/onboarding` returns `steps` array and `completedSteps`/`totalSteps` fields