### PR TITLE
feat: add regex validation for registrationNo in KybSubmitSchema

### DIFF
--- a/src/server/validations/kyb.schema.ts
+++ b/src/server/validations/kyb.schema.ts
@@ -21,7 +21,11 @@ export const KybSubmitSchema = z.object({
     .string()
     .min(1, "Registration number is required")
     .max(100, "Registration number is too long")
-    .trim(),
+    .trim()
+    .regex(
+      /^[A-Z0-9][A-Z0-9\-\/]{1,98}[A-Z0-9]$/i,
+      "Registration number must contain only letters, numbers, hyphens, or slashes (e.g. 12345678, AB-123456)"
+    ),
 });
 
 export type KybSubmitInput = z.infer<typeof KybSubmitSchema>;


### PR DESCRIPTION
Adds .regex() to the registrationNo field to enforce alphanumeric format with optional hyphens/slashes. Prevents junk data and aligns with KYB verification requirements.

# Pull Request

## Summary

<!-- Provide a brief overview of the changes in this PR -->

## Type of Change

<!-- Check the relevant option -->

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
- [ ] Infrastructure / CI

## Linked Issues

<!-- Link any related issues using "Fixes #123" or similar -->

## Key Changes

- <!-- List important code changes here -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new linting/type-checking warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation accordingly.

## Screenshots / Recordings

<!-- If applicable, add screenshots or screen recordings to demonstrate the changes -->
