### PR TITLE
feat: expose ledger age in health checks

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+const mockBlockchainService = {
+  isHealthy: vi.fn(),
+  getLedgerHealth: vi.fn(),
+};
+
+vi.mock("@/server/services/blockchain.service", () => ({
+  BlockchainService: vi.fn(function MockBlockchainService() {
+    return mockBlockchainService;
+  }),
+}));
+
+describe("GET /api/health", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return healthy status with ledger age", async () => {
+    mockBlockchainService.isHealthy.mockResolvedValue(true);
+    mockBlockchainService.getLedgerHealth.mockResolvedValue({
+      ledger: 1234,
+      ledgerAgeSeconds: 12,
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.message).toBe("System is healthy");
+    expect(data.data.ledger).toBe(1234);
+    expect(data.data.ledgerAgeSeconds).toBe(12);
+    expect(data.data.status).toBe("healthy");
+  });
+
+  it("should return degraded status when ledger age exceeds 60 seconds", async () => {
+    mockBlockchainService.isHealthy.mockResolvedValue(true);
+    mockBlockchainService.getLedgerHealth.mockResolvedValue({
+      ledger: 1234,
+      ledgerAgeSeconds: 61,
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toBe("System is degraded");
+    expect(data.data.status).toBe("degraded");
+    expect(data.data.ledgerAgeSeconds).toBe(61);
+  });
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "@/server/health/route";

--- a/src/server/health/route.ts
+++ b/src/server/health/route.ts
@@ -1,12 +1,25 @@
 import { ApiResponse } from "@/server/utils/api-response";
+import { BlockchainService } from "@/server/services/blockchain.service";
 
 export async function GET() {
+  const blockchainService = new BlockchainService();
+  const rpcHealthy = await blockchainService.isHealthy();
+  const ledgerHealth = await blockchainService.getLedgerHealth();
+  const degraded = ledgerHealth.ledgerAgeSeconds > 60;
+
   return ApiResponse.success(
     {
       uptime: process.uptime(),
       timestamp: new Date().toISOString(),
       environment: process.env.NODE_ENV,
+      ledger: ledgerHealth.ledger,
+      ledgerAgeSeconds: ledgerHealth.ledgerAgeSeconds,
+      status: !rpcHealthy ? "unhealthy" : degraded ? "degraded" : "healthy",
     },
-    "System is healthy"
+    !rpcHealthy
+      ? "System is unhealthy"
+      : degraded
+        ? "System is degraded"
+        : "System is healthy"
   );
 }

--- a/src/server/services/blockchain.service.spec.ts
+++ b/src/server/services/blockchain.service.spec.ts
@@ -626,6 +626,47 @@ describe("BlockchainService", () => {
     });
   });
 
+  describe("getLedgerHealth", () => {
+    it("should return latest ledger and age in seconds", async () => {
+      vi.setSystemTime(new Date("2026-03-26T12:40:00Z"));
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          _embedded: {
+            records: [
+              {
+                sequence: "1234",
+                closed_at: "2026-03-26T12:39:15Z",
+              },
+            ],
+          },
+        }),
+      });
+
+      const result = await service.getLedgerHealth();
+
+      expect(result).toEqual({
+        ledger: 1234,
+        ledgerAgeSeconds: 45,
+      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://horizon-testnet.stellar.org/ledgers?order=desc&limit=1",
+      );
+    });
+
+    it("should throw when latest ledger data is missing", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ _embedded: { records: [] } }),
+      });
+
+      await expect(service.getLedgerHealth()).rejects.toThrow(
+        /missing latest ledger data/i,
+      );
+    });
+  });
+
   describe("isHealthy", () => {
     it("should return true when RPC is healthy", async () => {
       mockRpcServer.getHealth.mockResolvedValue({ status: "healthy" });

--- a/src/server/services/blockchain.service.ts
+++ b/src/server/services/blockchain.service.ts
@@ -72,6 +72,11 @@ export interface SubmissionResult {
   resultXdr?: string;
 }
 
+export interface LedgerHealth {
+  ledger: number;
+  ledgerAgeSeconds: number;
+}
+
 export class BlockchainService {
   private rpcServer: RpcServer;
   private networkConfig: NetworkConfig;
@@ -389,6 +394,47 @@ export class BlockchainService {
 
   async getLatestLedger() {
     return this.rpcServer.getLatestLedger();
+  }
+
+  async getLedgerHealth(): Promise<LedgerHealth> {
+    const response = await fetch(
+      `${this.networkConfig.horizonUrl}/ledgers?order=desc&limit=1`,
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Horizon returned ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      _embedded?: {
+        records?: Array<{
+          sequence: number | string;
+          closed_at: string;
+        }>;
+      };
+    };
+
+    const latestLedger = data._embedded?.records?.[0];
+
+    if (!latestLedger?.closed_at || latestLedger.sequence == null) {
+      throw new Error("Horizon response missing latest ledger data");
+    }
+
+    const closedAtMs = Date.parse(latestLedger.closed_at);
+
+    if (Number.isNaN(closedAtMs)) {
+      throw new Error("Horizon returned an invalid ledger close time");
+    }
+
+    return {
+      ledger: Number(latestLedger.sequence),
+      ledgerAgeSeconds: Math.max(
+        0,
+        Math.floor((Date.now() - closedAtMs) / 1000),
+      ),
+    };
   }
 
   async isHealthy(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- add `getLedgerHealth()` to `BlockchainService` so the latest ledger sequence and age can be read from Horizon
- expose `/api/health` and include `ledger`, `ledgerAgeSeconds`, and degraded status when the ledger is more than 60 seconds behind
- add targeted tests for the new ledger health logic and health route response

## Testing
- npx vitest run src/server/services/blockchain.service.spec.ts src/app/api/health/route.test.ts
- npx tsx -e "import { GET } from '@/server/health/route'; import { BlockchainService } from '@/server/services/blockchain.service'; BlockchainService.prototype.isHealthy = async function () { return true; }; BlockchainService.prototype.getLedgerHealth = async function () { return { ledger: 4321, ledgerAgeSeconds: 18 }; }; (async () => { const response = await GET(); console.log(JSON.stringify(await response.json(), null, 2)); })();"