### PR TITLE
fix: improve responsive padding on address-book page

### DIFF
--- a/src/app/(dashboard)/settings/address-book/page.tsx
+++ b/src/app/(dashboard)/settings/address-book/page.tsx
@@ -130,8 +130,8 @@ export default function AddressBook() {
 
   return (
     <>
-      <section className="rounded-xl border border-[#e5e7eb] bg-white shadow-sm">
-        <div className="block md:flex items-center justify-between gap-4 px-4 sm:px-6 py-4 border-b border-[#eef2f7]">
+      <section className="rounded-xl border border-[#e5e7eb] bg-white shadow-sm px-4 sm:px-6 py-6">
+        <div className="block md:flex items-center justify-between gap-4 py-4 border-b border-[#eef2f7]">
           <div className="block items-center justify-between gap-4">
             <div>
               <h2 className="text-base sm:text-lg font-semibold text-[#1f2937]">
@@ -144,7 +144,7 @@ export default function AddressBook() {
         {/* Conditional rendering based on whether addresses exist */}
         {addresses.length === 0 ? (
           // Empty state
-          <div className="px-4 sm:px-6 py-10 sm:py-16">
+          <div className="py-10 sm:py-16">
             <div className="mx-auto flex max-w-md flex-col items-center text-center">
               <Image
                 src="/scope.png"
@@ -163,7 +163,7 @@ export default function AddressBook() {
           </div>
         ) : (
           // Addresses list
-          <div className="p-6">
+          <div>
             <div className="grid gap-6 md:grid-cols-2">
               {addresses.map((address) => (
                 <div


### PR DESCRIPTION
Closes #353 

## 📱 Fix: Responsive Layout Padding — Address Book Page

Fixes tight horizontal padding on mobile that caused content to touch screen edges.

### Changes (`src/app/(dashboard)/settings/address-book/page.tsx`)
- Added `px-4 sm:px-6 py-6` to the main section container — 16px on mobile, 24px on tablet/desktop
- Removed redundant padding from inner header and content containers since the parent now handles it
- Verified Empty State image is correctly centered and responsive (`w-[126px] sm:w-[180px]`, `mx-auto`)

### Result
Consistent, readable margins on mobile and desktop with no duplicate padding.