### PR TITLE
refactor: support naira currency symbol in payout history

### DIFF
--- a/src/app/(dashboard)/payroll/components/PayoutHistory.tsx
+++ b/src/app/(dashboard)/payroll/components/PayoutHistory.tsx
@@ -1,10 +1,10 @@
-"use client";
-import Table from "@/components/shared/table/Table";
-import { TableColumn } from "@/components/shared/table/TableHeader";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { UsdtIcon } from "@/../public/svg";
-import { RoutePaths } from "@/routes/routesPath";
+'use client';
+import Table from '@/components/shared/table/Table';
+import { TableColumn } from '@/components/shared/table/TableHeader';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { UsdtIcon } from '@/../public/svg';
+import { RoutePaths } from '@/routes/routesPath';
 
 interface Invoice {
   id: string;
@@ -12,7 +12,7 @@ interface Invoice {
   title: string;
   amount: number;
   paidIn: string;
-  status: "Pending" | "Overdue" | "Paid";
+  status: 'Pending' | 'Overdue' | 'Paid';
   issueDate: string;
   name?: string;
   number?: string;
@@ -22,45 +22,74 @@ interface Invoice {
 
 const invoices: Invoice[] = [
   {
-    id: "1",
-    invoiceNo: "20",
-    title: "$10/hr",
+    id: '1',
+    invoiceNo: '20',
+    title: '[CUR]10/hr',
     amount: 1200,
-    paidIn: "USDT",
-    status: "Pending",
-    issueDate: "25th Oct 2025",
-    name: "March April Invoice",
-    number: "20",
-    company: "Sample Company",
+    paidIn: 'NGN',
+    status: 'Pending',
+    issueDate: '25th Oct 2025',
+    name: 'Lagos Payroll Invoice',
+    number: '20',
+    company: 'Vestroll Nigeria',
   },
   {
-    id: "2",
-    invoiceNo: "14",
-    title: "$10/hr",
-    amount: 1200,
-    paidIn: "USDT",
-    status: "Overdue",
-    issueDate: "25th Oct 2025",
-    name: "March April Invoice",
-    number: "14",
-    company: "Sample Company",
+    id: '2',
+    invoiceNo: '14',
+    title: '[CUR]10/hr',
+    amount: 2400,
+    paidIn: 'USD',
+    status: 'Overdue',
+    issueDate: '25th Oct 2025',
+    name: 'North America Payroll Invoice',
+    number: '14',
+    company: 'Vestroll Inc.',
   },
   {
-    id: "3",
-    invoiceNo: "12",
-    title: "$10/hr",
-    amount: 1200,
-    paidIn: "USDT",
-    status: "Paid",
-    issueDate: "25th Oct 2025",
-    name: "March April Invoice",
-    number: "12",
-    company: "Sample Company",
+    id: '3',
+    invoiceNo: '12',
+    title: '[CUR]10/hr',
+    amount: 950,
+    paidIn: 'USDT',
+    status: 'Paid',
+    issueDate: '25th Oct 2025',
+    name: 'Treasury Settlement Invoice',
+    number: '12',
+    company: 'Vestroll Treasury',
   },
 ];
 
+const currencySymbolMap: Record<string, string> = {
+  NGN: '₦',
+  USD: '$',
+};
+
+function getCurrencyPrefix(currency: string): string {
+  return currencySymbolMap[currency] ?? currencySymbolMap.USD;
+}
+
+function formatAmount(amount: number, currency: string): string {
+  return `${getCurrencyPrefix(currency)}${amount.toLocaleString()}.00`;
+}
+
+function formatRate(title: string, currency: string): string {
+  if (title.includes('[CUR]')) {
+    return title.replace('[CUR]', getCurrencyPrefix(currency));
+  }
+
+  if (!title.startsWith('$')) {
+    return title;
+  }
+
+  return `${getCurrencyPrefix(currency)}${title.slice(1)}`;
+}
+
+function shouldShowCryptoIcon(currency: string): boolean {
+  return currency === 'USDT';
+}
+
 const PayoutHistory = () => {
-  const [search, setSearch] = useState<string>("");
+  const [search, setSearch] = useState<string>('');
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
 
   const router = useRouter();
@@ -71,25 +100,25 @@ const PayoutHistory = () => {
       invoice.number?.toLowerCase().includes(search.toLowerCase()) ||
       invoice.company?.toLowerCase().includes(search.toLowerCase()) ||
       invoice.title?.toLowerCase().includes(search.toLowerCase()) ||
-      invoice.invoiceNo?.toLowerCase().includes(search.toLowerCase())
+      invoice.invoiceNo?.toLowerCase().includes(search.toLowerCase()),
   );
 
   const invoiceColumns: TableColumn[] = [
-    { key: "invoiceNo", header: "Worked hours" },
-    { key: "title", header: "Rate" },
-    { key: "amount", header: "Calculated amount", align: "center" },
-    { key: "paidIn", header: "Paid in", align: "center" },
-    { key: "status", header: "Status", align: "center" },
-    { key: "issueDate", header: "Date", align: "right" },
+    { key: 'invoiceNo', header: 'Worked hours' },
+    { key: 'title', header: 'Rate' },
+    { key: 'amount', header: 'Calculated amount', align: 'center' },
+    { key: 'paidIn', header: 'Paid in', align: 'center' },
+    { key: 'status', header: 'Status', align: 'center' },
+    { key: 'issueDate', header: 'Date', align: 'right' },
   ];
 
-  const getStatusBadge = (status: Invoice["status"]) => {
+  const getStatusBadge = (status: Invoice['status']) => {
     switch (status) {
-      case "Pending":
+      case 'Pending':
         return ` border-[#E79A23] bg-[#FEF7EB] text-[#E79A23]`;
-      case "Overdue":
+      case 'Overdue':
         return `border-[#C64242] bg-[#FEECEC] text-[#C64242]`;
-      case "Paid":
+      case 'Paid':
         return `border-[#26902B] bg-[#EDFEEC] text-[#26902B]`;
       default:
         return;
@@ -98,72 +127,76 @@ const PayoutHistory = () => {
 
   const renderInvoiceCell = (item: Invoice, column: TableColumn) => {
     switch (column.key) {
-      case "title":
+      case 'title':
         return (
-          <div className="text-text-header font-semibold">{item.title}</div>
-        );
-      case "amount":
-        return (
-          <div className="text-text-header font-semibold">
-            {item.amount.toLocaleString()}.00
+          <div className="font-semibold text-text-header">
+            {formatRate(item.title, item.paidIn)}
           </div>
         );
-      case "paidIn":
+      case 'amount':
+        return (
+          <div className="font-semibold text-text-header">
+            {formatAmount(item.amount, item.paidIn)}
+          </div>
+        );
+      case 'paidIn':
         return (
           <div className="flex items-center font-medium gap-1 py-1.5 px-3 border border-border-primary bg-fill-background rounded-full w-fit mx-auto">
-            <UsdtIcon />
+            {shouldShowCryptoIcon(item.paidIn) ? <UsdtIcon /> : null}
             <span className="text-text-header">{item.paidIn}</span>
           </div>
         );
-      case "status":
+      case 'status':
         return (
           <span
             className={`px-2 py-1 rounded-full text-sm font-semibold border ${getStatusBadge(
-              item.status
+              item.status,
             )}`}
           >
             {item.status}
           </span>
         );
-      case "invoiceNo":
+      case 'invoiceNo':
         return <p className="font-medium text-gray-900">{item.invoiceNo}</p>;
-      case "title":
+      case 'title':
         return <span className="text-gray-600">{item.title}</span>;
-      case "issueDate":
+      case 'issueDate':
         return <span className="text-gray-600">{item.issueDate}</span>;
       default:
         return (
           (item as Record<string, string | number | undefined>)[column.key] ||
-          "-"
+          '-'
         );
     }
   };
 
   const renderMobileCell = (item: Invoice) => (
-    <div className="flex gap-4 justify-between w-full">
-      <div className="space-y-2 flex-1 min-w-0">
-        <p className="truncate font-semibold text-gray-500">
-          {item.invoiceNo} @ {item.title}
+    <div className="flex justify-between w-full gap-4">
+      <div className="flex-1 min-w-0 space-y-2">
+        <p className="font-semibold text-gray-500 truncate">
+          {item.invoiceNo} @ {formatRate(item.title, item.paidIn)}
         </p>
         <span className="flex items-center gap-2 ">
-          <p className="text-xs font-medium text-gray-300">{item.amount}</p>
+          <p className="text-xs font-medium text-gray-300">
+            {formatAmount(item.amount, item.paidIn)}
+          </p>
 
-          <div className="w-px self-stretch bg-gray-150" />
+          <div className="self-stretch w-px bg-gray-150" />
 
-          <div className="flex items-center font-medium gap-1 ">
-            <UsdtIcon />
+          <div className="flex items-center gap-1 font-medium ">
+            {shouldShowCryptoIcon(item.paidIn) ? <UsdtIcon /> : null}
 
-            <span className="text-gray-600 text-sm font-medium">
+            <span className="text-sm font-medium text-gray-600">
               {item.paidIn}
             </span>
           </div>
         </span>
       </div>
 
-      <div className="space-y-2 shrink-0  flex flex-col items-end justify-between">
+      <div className="flex flex-col items-end justify-between space-y-2 shrink-0">
         <span
           className={`px-2 py-1 rounded-full text-xs font-semibold border ${getStatusBadge(
-            item.status
+            item.status,
           )}`}
         >
           {item.status}
@@ -185,20 +218,20 @@ const PayoutHistory = () => {
   // Handle select all
   const handleSelectAll = (checked: boolean) => {
     setSelectedItems(
-      checked ? filteredInvoices.map((invoice) => invoice.id) : []
+      checked ? filteredInvoices.map((invoice) => invoice.id) : [],
     );
   };
 
   const handleRowClick = (invoice: Invoice) => {
-    router.push(`${RoutePaths.INVOICES}/${invoice.invoiceNo.replace("#", "")}`);
+    router.push(`${RoutePaths.INVOICES}/${invoice.invoiceNo.replace('#', '')}`);
   };
 
   const showModal = () => {
-    console.log("Show filter modal");
+    console.log('Show filter modal');
   };
 
   return (
-    <div className="bg-white p-4 rounded-sm shadow w-full space-y-2">
+    <div className="w-full p-4 space-y-2 bg-white rounded-sm shadow">
       <span
         className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium border text-[#5A42DE] border-[#5A42DE] bg-[#E8E5FA] `}
       >
@@ -220,11 +253,11 @@ const PayoutHistory = () => {
         onSelectAll={handleSelectAll}
         onRowClick={handleRowClick}
         renderCell={renderInvoiceCell}
-        emptyTitle={search ? "No invoices found" : "No invoices yet"}
+        emptyTitle={search ? 'No invoices found' : 'No invoices yet'}
         emptyDescription={
           search
             ? `No invoices match "${search}". Try adjusting your search.`
-            : "Invoices sent to you will be displayed here"
+            : 'Invoices sent to you will be displayed here'
         }
         renderMobileCell={renderMobileCell}
       />


### PR DESCRIPTION
# Pull Request

## Summary

This PR adds support for Naira currency symbol in payout History for fiat transactions to provide a localized experience.

## Type of Change

<!-- Check the relevant option -->

- [x] Feature
- [ ] Bug Fix
- [x] Refactoring
- [ ] Documentation
- [ ] Tests
- [ ] Infrastructure / CI

## Linked Issues

Closes #352 

## Key Changes

- Kept one NGN sample row so the ₦ path is visible
- Changed another row to USD for a second fiat case
- Kept one USDT row for the crypto case
- Updated sample names and companies so each case is easier to distinguish
- Stopped rendering the `UsdtIcon` for fiat rows, so only crypto rows show the crypto badge icon

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new linting/type-checking warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation accordingly.
