### PR TITLE
feat(team): add bank details step to new employee wizard (#349)

### DIFF
--- a/src/components/features/team-management/add-employee-wizard/AddEmployeeWizard.tsx
+++ b/src/components/features/team-management/add-employee-wizard/AddEmployeeWizard.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import React, { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogDescription 
+} from "@/components/ui/dialog";
+import Stepper from "@/components/ui/stepper";
+import { 
+  WizardFormData, 
+  WIZARD_STEPS, 
+  BasicInfoData, 
+  PaymentMethodData, 
+  BankDetailsData 
+} from "./types";
+import { Step1BasicInfo } from "./steps/Step1BasicInfo";
+import { Step2PaymentMethod } from "./steps/Step2PaymentMethod";
+import { Step3PaymentDetails } from "./steps/Step3PaymentDetails";
+import { Step4Review } from "./steps/Step4Review";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Loader2, X } from "lucide-react";
+
+interface AddEmployeeWizardProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: (data: WizardFormData) => Promise<void>;
+}
+
+const INITIAL_DATA: WizardFormData = {
+  basicInfo: {
+    firstName: "",
+    lastName: "",
+    email: "",
+    role: "",
+    department: "",
+    type: "Freelancer",
+  },
+  paymentMethod: {
+    paymentMethod: "fiat",
+  },
+  bankDetails: {
+    bankName: "",
+    accountNumber: "",
+    accountName: "",
+  },
+};
+
+export function AddEmployeeWizard({ 
+  isOpen, 
+  onClose, 
+  onSuccess 
+}: AddEmployeeWizardProps) {
+  const [activeStep, setActiveStep] = useState(0);
+  const [formData, setFormData] = useState<WizardFormData>(INITIAL_DATA);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleNext = (stepData: Partial<WizardFormData[keyof WizardFormData]>) => {
+    const stepKey = 
+      activeStep === 0 ? "basicInfo" : 
+      activeStep === 1 ? "paymentMethod" : 
+      activeStep === 2 ? "bankDetails" : null;
+
+    if (stepKey) {
+      setFormData(prev => ({
+        ...prev,
+        [stepKey]: { ...prev[stepKey], ...stepData }
+      }));
+    }
+
+    // Skip bank details if crypto is selected
+    if (activeStep === 1 && (stepData as PaymentMethodData).paymentMethod === "crypto") {
+      setActiveStep(3); // Go directly to Review
+    } else {
+      setActiveStep(prev => prev + 1);
+    }
+  };
+
+  const handleBack = () => {
+    // If coming back from Review and crypto was selected, go to Step 2
+    if (activeStep === 3 && formData.paymentMethod.paymentMethod === "crypto") {
+      setActiveStep(1);
+    } else {
+      setActiveStep(prev => prev - 1);
+    }
+  };
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    try {
+      await onSuccess(formData);
+      onClose();
+      setFormData(INITIAL_DATA);
+      setActiveStep(0);
+    } catch (error) {
+      console.error("Failed to add employee:", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const renderStep = () => {
+    switch (activeStep) {
+      case 0:
+        return (
+          <Step1BasicInfo 
+            defaultValues={formData.basicInfo} 
+            onNext={(data) => handleNext(data)} 
+          />
+        );
+      case 1:
+        return (
+          <Step2PaymentMethod 
+            defaultValues={formData.paymentMethod} 
+            onNext={(data) => handleNext(data)} 
+            onBack={handleBack}
+          />
+        );
+      case 2:
+        return (
+          <Step3PaymentDetails 
+            defaultValues={formData.bankDetails} 
+            onNext={(data) => handleNext(data)} 
+            onBack={handleBack}
+          />
+        );
+      case 3:
+        return (
+          <Step4Review 
+            formData={formData} 
+            onSubmit={handleSubmit} 
+            onBack={handleBack}
+            isSubmitting={isSubmitting}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[640px] p-0 overflow-hidden border-none bg-white dark:bg-gray-950 shadow-2xl rounded-2xl">
+        <div className="flex flex-col h-full max-h-[90vh]">
+          {/* Header */}
+          <div className="px-6 py-6 border-b border-gray-100 dark:border-gray-800">
+            <div className="flex justify-between items-start mb-6">
+              <div>
+                <DialogTitle className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+                  Add New Employee
+                </DialogTitle>
+                <DialogDescription className="text-gray-500 dark:text-gray-400">
+                  Follow the steps to onboard a new team member.
+                </DialogDescription>
+              </div>
+              <button 
+                onClick={onClose}
+                className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+              >
+                <X className="h-5 w-5 text-gray-400" />
+              </button>
+            </div>
+
+            <div className="mb-2">
+              <div className="flex justify-between text-xs font-medium text-gray-400 mb-2 uppercase tracking-widest">
+                <span>Step {activeStep + 1} of {WIZARD_STEPS.length}</span>
+                <span>{WIZARD_STEPS[activeStep].label}</span>
+              </div>
+              <Stepper 
+                steps={WIZARD_STEPS.map(s => s.label)} 
+                activeStep={activeStep} 
+                setActiveStep={(step) => {
+                  // Optional: allow jumping back but not forward past visited steps
+                  if (step < activeStep) setActiveStep(step);
+                }} 
+              />
+            </div>
+          </div>
+
+          {/* Body */}
+          <div className="flex-1 overflow-y-auto p-6 scrollbar-hide">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={activeStep}
+                initial={{ opacity: 0, x: 10 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -10 }}
+                transition={{ duration: 0.2 }}
+              >
+                {renderStep()}
+              </motion.div>
+            </AnimatePresence>
+          </div>
+
+          {/* Footer - Step 1 has button inside its form for easier submit handling */}
+          {activeStep === 0 && (
+            <div className="px-6 py-4 bg-gray-50/50 dark:bg-gray-900/50 border-t border-gray-100 dark:border-gray-800 flex justify-end">
+              <Button 
+                type="submit" 
+                form="step1-form"
+                className="px-8 bg-primary-600 hover:bg-primary-700 text-white font-semibold"
+              >
+                Next Step
+              </Button>
+            </div>
+          )}
+          
+          {/* Step 3 footer also handled internally for verification logic */}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/features/team-management/add-employee-wizard/index.ts
+++ b/src/components/features/team-management/add-employee-wizard/index.ts
@@ -1,0 +1,2 @@
+export * from "./AddEmployeeWizard";
+export * from "./types";

--- a/src/components/features/team-management/add-employee-wizard/steps/Step1BasicInfo.tsx
+++ b/src/components/features/team-management/add-employee-wizard/steps/Step1BasicInfo.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { User, Mail, Briefcase, Building2, Users } from "lucide-react";
+import { BasicInfoData } from "../types";
+
+const schema = z.object({
+  firstName: z.string().min(1, "First name is required").max(255),
+  lastName: z.string().min(1, "Last name is required").max(255),
+  email: z.string().email("Enter a valid email address"),
+  role: z.string().min(1, "Role is required"),
+  department: z.string().min(1, "Department is required"),
+  type: z.enum(["Freelancer", "Contractor"]),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  defaultValues: BasicInfoData;
+  onNext: (data: BasicInfoData) => void;
+}
+
+const departmentOptions = [
+  "Engineering",
+  "Design",
+  "Product",
+  "Marketing",
+  "Sales",
+  "Finance",
+  "HR",
+  "Operations",
+  "Legal",
+  "Other",
+];
+
+export function Step1BasicInfo({ defaultValues, onNext }: Props) {
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues,
+  });
+
+  const selectedType = watch("type");
+  const selectedDept = watch("department");
+
+  return (
+    <form
+      id="step1-form"
+      onSubmit={handleSubmit(onNext)}
+      className="space-y-5"
+    >
+      {/* Name row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="firstName">First Name</Label>
+          <div className="relative">
+            <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+            <Input
+              id="firstName"
+              placeholder="John"
+              className="pl-9"
+              {...register("firstName")}
+            />
+          </div>
+          {errors.firstName && (
+            <p className="text-xs text-red-500">{errors.firstName.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="lastName">Last Name</Label>
+          <div className="relative">
+            <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+            <Input
+              id="lastName"
+              placeholder="Doe"
+              className="pl-9"
+              {...register("lastName")}
+            />
+          </div>
+          {errors.lastName && (
+            <p className="text-xs text-red-500">{errors.lastName.message}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Email */}
+      <div className="space-y-1.5">
+        <Label htmlFor="email">Email Address</Label>
+        <div className="relative">
+          <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+          <Input
+            id="email"
+            type="email"
+            placeholder="john.doe@company.com"
+            className="pl-9"
+            {...register("email")}
+          />
+        </div>
+        {errors.email && (
+          <p className="text-xs text-red-500">{errors.email.message}</p>
+        )}
+      </div>
+
+      {/* Role */}
+      <div className="space-y-1.5">
+        <Label htmlFor="role">Job Title / Role</Label>
+        <div className="relative">
+          <Briefcase className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+          <Input
+            id="role"
+            placeholder="e.g. Senior Engineer"
+            className="pl-9"
+            {...register("role")}
+          />
+        </div>
+        {errors.role && (
+          <p className="text-xs text-red-500">{errors.role.message}</p>
+        )}
+      </div>
+
+      {/* Department + Type row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Department</Label>
+          <Select
+            value={selectedDept}
+            onValueChange={(v) => setValue("department", v)}
+          >
+            <SelectTrigger id="department">
+              <Building2 className="h-4 w-4 mr-2 text-gray-400" />
+              <SelectValue placeholder="Select department" />
+            </SelectTrigger>
+            <SelectContent>
+              {departmentOptions.map((d) => (
+                <SelectItem key={d} value={d}>
+                  {d}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.department && (
+            <p className="text-xs text-red-500">{errors.department.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Employment Type</Label>
+          <Select
+            value={selectedType}
+            onValueChange={(v) => setValue("type", v as "Freelancer" | "Contractor")}
+          >
+            <SelectTrigger id="type">
+              <Users className="h-4 w-4 mr-2 text-gray-400" />
+              <SelectValue placeholder="Select type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Freelancer">Freelancer</SelectItem>
+              <SelectItem value="Contractor">Contractor</SelectItem>
+            </SelectContent>
+          </Select>
+          {errors.type && (
+            <p className="text-xs text-red-500">{errors.type.message}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Footer button rendered by parent via form id */}
+    </form>
+  );
+}

--- a/src/components/features/team-management/add-employee-wizard/steps/Step2PaymentMethod.tsx
+++ b/src/components/features/team-management/add-employee-wizard/steps/Step2PaymentMethod.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import React from "react";
+import { Bitcoin, Landmark } from "lucide-react";
+import { PaymentMethodData, PaymentMethod } from "../types";
+
+interface Props {
+  defaultValues: PaymentMethodData;
+  onNext: (data: PaymentMethodData) => void;
+  onBack: () => void;
+}
+
+const OPTIONS: {
+  value: PaymentMethod;
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "fiat",
+    icon: <Landmark className="h-7 w-7" />,
+    label: "Bank Transfer (Fiat)",
+    description: "Pay via bank account. Bank details will be collected next.",
+  },
+  {
+    value: "crypto",
+    icon: <Bitcoin className="h-7 w-7" />,
+    label: "Crypto Wallet",
+    description: "Pay in cryptocurrency. Wallet address collected separately.",
+  },
+];
+
+export function Step2PaymentMethod({ defaultValues, onNext, onBack }: Props) {
+  const [selected, setSelected] = React.useState<PaymentMethod>(
+    defaultValues.paymentMethod
+  );
+
+  const handleContinue = () => {
+    onNext({ paymentMethod: selected });
+  };
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        Choose how this employee will be paid. If{" "}
+        <span className="font-medium text-gray-700 dark:text-gray-200">
+          Fiat
+        </span>{" "}
+        is selected, you will provide bank details in the next step.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {OPTIONS.map((opt) => {
+          const isActive = selected === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setSelected(opt.value)}
+              className={`
+                relative flex flex-col items-start gap-3 p-5 rounded-xl border-2 text-left
+                transition-all duration-200 cursor-pointer
+                ${
+                  isActive
+                    ? "border-primary-500 bg-primary-500/5 shadow-sm"
+                    : "border-gray-200 dark:border-gray-700 hover:border-primary-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+                }
+              `}
+            >
+              {/* Selected dot */}
+              <span
+                className={`
+                  absolute top-3 right-3 h-4 w-4 rounded-full border-2 flex items-center justify-center
+                  transition-colors duration-200
+                  ${isActive ? "border-primary-500 bg-primary-500" : "border-gray-300 bg-white dark:bg-gray-900"}
+                `}
+              >
+                {isActive && (
+                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
+                )}
+              </span>
+
+              <span
+                className={`
+                  p-2.5 rounded-lg
+                  ${isActive ? "bg-primary-500/10 text-primary-600" : "bg-gray-100 dark:bg-gray-800 text-gray-500"}
+                `}
+              >
+                {opt.icon}
+              </span>
+
+              <div>
+                <p
+                  className={`font-semibold text-sm ${isActive ? "text-primary-600 dark:text-primary-400" : "text-gray-800 dark:text-gray-100"}`}
+                >
+                  {opt.label}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  {opt.description}
+                </p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-between pt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
+        >
+          ← Back
+        </button>
+        <button
+          type="button"
+          onClick={handleContinue}
+          className="px-5 py-2 rounded-lg bg-primary-500 text-white text-sm font-medium hover:bg-primary-600 transition-colors"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/team-management/add-employee-wizard/steps/Step3PaymentDetails.tsx
+++ b/src/components/features/team-management/add-employee-wizard/steps/Step3PaymentDetails.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Building,
+  Hash,
+  ContactRound,
+} from "lucide-react";
+import { BankDetailsData } from "../types";
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const schema = z.object({
+  bankName: z.string().min(1, "Bank name is required"),
+  accountNumber: z
+    .string()
+    .min(6, "Account number must be at least 6 digits")
+    .max(25, "Account number cannot exceed 25 digits")
+    .regex(/^\d+$/, "Account number must contain only numbers"),
+  accountName: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+// ─── Nigerian banks list (common subset) ─────────────────────────────────────
+
+const BANK_OPTIONS = [
+  "Access Bank",
+  "Citibank Nigeria",
+  "Ecobank Nigeria",
+  "Fidelity Bank",
+  "First Bank of Nigeria",
+  "First City Monument Bank (FCMB)",
+  "Guaranty Trust Bank (GTBank)",
+  "Heritage Bank",
+  "Keystone Bank",
+  "Polaris Bank",
+  "Stanbic IBTC Bank",
+  "Standard Chartered Bank",
+  "Sterling Bank",
+  "Union Bank of Nigeria",
+  "United Bank for Africa (UBA)",
+  "Unity Bank",
+  "Wema Bank",
+  "Zenith Bank",
+  "Other",
+];
+
+// ─── Verification state type ──────────────────────────────────────────────────
+
+type VerificationState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; accountName: string }
+  | { status: "error"; message: string };
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  defaultValues: BankDetailsData;
+  onNext: (data: BankDetailsData) => void;
+  onBack: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function Step3PaymentDetails({ defaultValues, onNext, onBack }: Props) {
+  const [verification, setVerification] = useState<VerificationState>({
+    status: "idle",
+  });
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    trigger,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      bankName: defaultValues.bankName,
+      accountNumber: defaultValues.accountNumber,
+      accountName: defaultValues.accountName,
+    },
+  });
+
+  const selectedBank = watch("bankName");
+  const accountNumber = watch("accountNumber");
+
+  // ── Account verification ────────────────────────────────────────────────────
+  const verifyAccount = async () => {
+    const valid = await trigger(["bankName", "accountNumber"]);
+    if (!valid) return;
+
+    setVerification({ status: "loading" });
+
+    try {
+      const res = await fetch("/api/accounts/validate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankName: selectedBank, accountNumber }),
+      });
+      const json = await res.json();
+
+      if (!res.ok) throw new Error(json.message || "Verification failed");
+
+      const resolvedName: string =
+        json.data?.accountHolderName ||
+        json.data?.accountName ||
+        "Account Verified";
+
+      setValue("accountName", resolvedName);
+      setVerification({ status: "success", accountName: resolvedName });
+    } catch (err) {
+      setVerification({
+        status: "error",
+        message:
+          err instanceof Error ? err.message : "Could not verify account",
+      });
+    }
+  };
+
+  // ── Submit ──────────────────────────────────────────────────────────────────
+  const onSubmit = (values: FormValues) => {
+    onNext({
+      bankName: values.bankName,
+      accountNumber: values.accountNumber,
+      accountName:
+        verification.status === "success"
+          ? verification.accountName
+          : values.accountName || "",
+    });
+  };
+
+  const canVerify =
+    selectedBank.length > 0 &&
+    accountNumber.length >= 6 &&
+    /^\d+$/.test(accountNumber);
+
+  const isVerified = verification.status === "success";
+
+  return (
+    <form
+      id="step3-form"
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-6"
+    >
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        Enter the employee&apos;s bank details. Verify the account number to
+        auto-fill the account name before proceeding.
+      </p>
+
+      {/* Bank Name */}
+      <div className="space-y-1.5">
+        <Label htmlFor="bankName">Bank Name</Label>
+        <Select
+          value={selectedBank}
+          onValueChange={(v) => {
+            setValue("bankName", v);
+            setVerification({ status: "idle" });
+          }}
+        >
+          <SelectTrigger id="bankName" className="w-full">
+            <Building className="h-4 w-4 mr-2 text-gray-400 shrink-0" />
+            <SelectValue placeholder="Select a bank…" />
+          </SelectTrigger>
+          <SelectContent className="max-h-72 overflow-y-auto">
+            {BANK_OPTIONS.map((b) => (
+              <SelectItem key={b} value={b}>
+                {b}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {errors.bankName && (
+          <p className="text-xs text-red-500">{errors.bankName.message}</p>
+        )}
+      </div>
+
+      {/* Account Number + Verify button */}
+      <div className="space-y-1.5">
+        <Label htmlFor="accountNumber">Account Number</Label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Hash className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+            <Input
+              id="accountNumber"
+              placeholder="0123456789"
+              className="pl-9 tracking-widest font-mono"
+              maxLength={25}
+              {...register("accountNumber", {
+                onChange: () => setVerification({ status: "idle" }),
+              })}
+            />
+          </div>
+          <button
+            type="button"
+            disabled={!canVerify || verification.status === "loading"}
+            onClick={verifyAccount}
+            className={`
+              shrink-0 px-4 py-2 rounded-lg text-sm font-medium border transition-colors
+              ${
+                canVerify && verification.status !== "loading"
+                  ? "border-primary-500 text-primary-600 hover:bg-primary-500/10 dark:text-primary-400 dark:border-primary-400"
+                  : "border-gray-200 text-gray-400 cursor-not-allowed dark:border-gray-700"
+              }
+            `}
+          >
+            {verification.status === "loading" ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              "Verify"
+            )}
+          </button>
+        </div>
+        {errors.accountNumber && (
+          <p className="text-xs text-red-500">{errors.accountNumber.message}</p>
+        )}
+      </div>
+
+      {/* Verification feedback */}
+      {verification.status === "success" && (
+        <div className="flex items-center gap-2 px-3 py-2.5 rounded-lg bg-green-50 border border-green-200 dark:bg-green-900/20 dark:border-green-800">
+          <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400 shrink-0" />
+          <p className="text-sm text-green-700 dark:text-green-300">
+            Account verified
+          </p>
+        </div>
+      )}
+      {verification.status === "error" && (
+        <div className="flex items-center gap-2 px-3 py-2.5 rounded-lg bg-red-50 border border-red-200 dark:bg-red-900/20 dark:border-red-800">
+          <XCircle className="h-4 w-4 text-red-600 dark:text-red-400 shrink-0" />
+          <p className="text-sm text-red-700 dark:text-red-300">
+            {verification.message}
+          </p>
+        </div>
+      )}
+
+      {/* Account Name — read-only, auto-filled */}
+      <div className="space-y-1.5">
+        <Label htmlFor="accountName">
+          Account Name{" "}
+          <span className="text-xs font-normal text-gray-400">
+            (auto-filled after verification)
+          </span>
+        </Label>
+        <div className="relative">
+          <ContactRound className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+          <Input
+            id="accountName"
+            placeholder="Verified name will appear here"
+            className={`pl-9 ${isVerified ? "bg-gray-50 dark:bg-gray-800 font-medium" : "text-gray-400"}`}
+            readOnly
+            {...register("accountName")}
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-between pt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
+        >
+          ← Back
+        </button>
+        <button
+          type="submit"
+          disabled={!isVerified}
+          title={!isVerified ? "Verify account number first" : undefined}
+          className={`
+            px-5 py-2 rounded-lg text-sm font-medium transition-colors
+            ${
+              isVerified
+                ? "bg-primary-500 text-white hover:bg-primary-600"
+                : "bg-gray-200 text-gray-400 cursor-not-allowed dark:bg-gray-700"
+            }
+          `}
+        >
+          Continue
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/features/team-management/add-employee-wizard/steps/Step4Review.tsx
+++ b/src/components/features/team-management/add-employee-wizard/steps/Step4Review.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React from "react";
+import { 
+  User, 
+  Mail, 
+  Briefcase, 
+  Building2, 
+  Users, 
+  Landmark, 
+  Bitcoin,
+  ChevronRight,
+  CheckCircle2
+} from "lucide-react";
+import { WizardFormData } from "../types";
+import { Badge } from "@/components/ui/badge";
+
+interface Props {
+  formData: WizardFormData;
+  onSubmit: () => void;
+  onBack: () => void;
+  isSubmitting?: boolean;
+}
+
+export function Step4Review({ formData, onSubmit, onBack, isSubmitting = false }: Props) {
+  const { basicInfo, paymentMethod, bankDetails } = formData;
+
+  return (
+    <div className="space-y-8">
+      <div className="bg-primary-50 dark:bg-primary-950/20 border border-primary-100 dark:border-primary-900 rounded-xl p-4 flex gap-3">
+        <CheckCircle2 className="h-5 w-5 text-primary-600 shrink-0" />
+        <p className="text-sm text-primary-800 dark:text-primary-300">
+          Please review the employee information below. Once confirmed, an onboarding invitation will be sent.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 text-sm">
+        {/* Basic Info Section */}
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 pb-2 border-b border-gray-100 dark:border-gray-800">
+            <User className="h-4 w-4 text-gray-400" />
+            <h3 className="font-semibold text-gray-900 dark:text-white uppercase tracking-wider text-xs">
+              Basic Information
+            </h3>
+          </div>
+          
+          <div className="space-y-3">
+            <div className="flex justify-between">
+              <span className="text-gray-500">Full Name</span>
+              <span className="font-medium text-gray-900 dark:text-gray-100">{basicInfo.firstName} {basicInfo.lastName}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Email</span>
+              <span className="font-medium text-gray-900 dark:text-gray-100">{basicInfo.email}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Role</span>
+              <span className="font-medium text-gray-900 dark:text-gray-100">{basicInfo.role}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Department</span>
+              <span className="font-medium text-gray-900 dark:text-gray-100">{basicInfo.department}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Type</span>
+              <Badge variant="outline" className="font-normal rounded-full">
+                {basicInfo.type}
+              </Badge>
+            </div>
+          </div>
+        </div>
+
+        {/* Payment Section */}
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 pb-2 border-b border-gray-100 dark:border-gray-800">
+            <Landmark className="h-4 w-4 text-gray-400" />
+            <h3 className="font-semibold text-gray-900 dark:text-white uppercase tracking-wider text-xs">
+              Payment Details
+            </h3>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex justify-between items-center">
+              <span className="text-gray-500">Method</span>
+              <div className="flex items-center gap-2 font-medium text-gray-900 dark:text-gray-100">
+                {paymentMethod.paymentMethod === "fiat" ? (
+                  <>
+                    <Landmark className="h-4 w-4 text-primary-600" />
+                    <span>Bank Transfer (Fiat)</span>
+                  </>
+                ) : (
+                  <>
+                    <Bitcoin className="h-4 w-4 text-orange-500" />
+                    <span>Crypto Wallet</span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {paymentMethod.paymentMethod === "fiat" && (
+              <>
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Bank Name</span>
+                  <span className="font-medium text-gray-900 dark:text-gray-100">{bankDetails.bankName}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Account Number</span>
+                  <span className="font-medium font-mono text-gray-900 dark:text-gray-100">{bankDetails.accountNumber}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Account Name</span>
+                  <span className="font-medium text-primary-700 dark:text-primary-400">{bankDetails.accountName}</span>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Footer Actions */}
+      <div className="flex justify-between pt-6 border-t border-gray-100 dark:border-gray-800">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={isSubmitting}
+          className="text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
+        >
+          ← Back to details
+        </button>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={isSubmitting}
+          className={`
+            flex items-center gap-2 px-6 py-2.5 rounded-lg text-sm font-semibold transition-all
+            bg-primary-600 text-white hover:bg-primary-700 shadow-md hover:shadow-lg
+            disabled:opacity-50 disabled:cursor-not-allowed
+          `}
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Processing...
+            </>
+          ) : (
+            <>
+              Confirm & Add Employee
+              <ChevronRight className="h-4 w-4" />
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Loader2({ className }: { className?: string }) {
+  return (
+    <svg 
+      className={className}
+      xmlns="http://www.w3.org/2000/svg" 
+      width="24" 
+      height="24" 
+      viewBox="0 0 24 24" 
+      fill="none" 
+      stroke="currentColor" 
+      strokeWidth="2" 
+      strokeLinecap="round" 
+      strokeLinejoin="round"
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+    </svg>
+  );
+}

--- a/src/components/features/team-management/add-employee-wizard/types.ts
+++ b/src/components/features/team-management/add-employee-wizard/types.ts
@@ -1,0 +1,33 @@
+export type PaymentMethod = "crypto" | "fiat";
+
+export interface BasicInfoData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: string;
+  department: string;
+  type: "Freelancer" | "Contractor";
+}
+
+export interface PaymentMethodData {
+  paymentMethod: PaymentMethod;
+}
+
+export interface BankDetailsData {
+  bankName: string;
+  accountNumber: string;
+  accountName: string; // read-only, populated after verification
+}
+
+export interface WizardFormData {
+  basicInfo: BasicInfoData;
+  paymentMethod: PaymentMethodData;
+  bankDetails: BankDetailsData;
+}
+
+export const WIZARD_STEPS = [
+  { id: 1, label: "Basic Info" },
+  { id: 2, label: "Payment Method" },
+  { id: 3, label: "Payment Details" },
+  { id: 4, label: "Review" },
+] as const;

--- a/src/components/features/team-management/employees.tsx
+++ b/src/components/features/team-management/employees.tsx
@@ -10,6 +10,9 @@ import { StatsBar } from "@/components/features/team-management/StatsBar";
 import { EmployeeList } from "@/components/features/team-management/EmployeeList";
 import { useSort } from "@/hooks/use-sort";
 import { Employee } from "@/types/teamManagement.types";
+import { AddEmployeeWizard, WizardFormData } from "./add-employee-wizard";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface TeamMgtEmployeesProps {
   employees: Employee[];
@@ -17,6 +20,7 @@ interface TeamMgtEmployeesProps {
 
 const TeamMgtEmployees: React.FC<TeamMgtEmployeesProps> = ({ employees }) => {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [isAddEmployeeOpen, setIsAddEmployeeOpen] = useState(false);
 
   const {
     data: paginatedEmployees,
@@ -47,6 +51,16 @@ const TeamMgtEmployees: React.FC<TeamMgtEmployeesProps> = ({ employees }) => {
     setFilters(newFilters);
   };
 
+  const handleAddEmployeeSuccess = async (data: WizardFormData) => {
+    // Mocking an API call
+    console.log("Adding new employee with wizard data:", data);
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 1500);
+    });
+  };
+
   const employeeFilterConfig = [
     {
       key: "status",
@@ -70,7 +84,12 @@ const TeamMgtEmployees: React.FC<TeamMgtEmployeesProps> = ({ employees }) => {
   if (employees.length === 0) {
     return (
       <div className="bg-white rounded-lg border border-gray-200">
-        <TeamEmptyState onAddEmployee={() => console.log("Add employee")} />
+        <TeamEmptyState onAddEmployee={() => setIsAddEmployeeOpen(true)} />
+        <AddEmployeeWizard 
+          isOpen={isAddEmployeeOpen} 
+          onClose={() => setIsAddEmployeeOpen(false)} 
+          onSuccess={handleAddEmployeeSuccess}
+        />
       </div>
     );
   }
@@ -95,6 +114,13 @@ const TeamMgtEmployees: React.FC<TeamMgtEmployeesProps> = ({ employees }) => {
               onFilterClick={() => setIsFilterOpen(true)}
             />
           </div>
+          <Button 
+            onClick={() => setIsAddEmployeeOpen(true)}
+            className="bg-primary-600 hover:bg-primary-700 text-white flex items-center gap-2"
+          >
+            <Plus className="h-4 w-4" />
+            <span className="hidden sm:inline">Add Member</span>
+          </Button>
         </div>
       </div>
 
@@ -139,6 +165,12 @@ const TeamMgtEmployees: React.FC<TeamMgtEmployeesProps> = ({ employees }) => {
         filters={filters}
         onApply={handleFilterApply}
         filterConfiguration={employeeFilterConfig}
+      />
+
+      <AddEmployeeWizard 
+        isOpen={isAddEmployeeOpen} 
+        onClose={() => setIsAddEmployeeOpen(false)} 
+        onSuccess={handleAddEmployeeSuccess}
       />
     </>
   );


### PR DESCRIPTION
Closes #349

## Changes

### `src/components/features/team-management/add-employee-wizard/` (NEW)
- `types.ts` — shared wizard form types
- `AddEmployeeWizard.tsx` — multi-step modal with stepper + step routing
- `steps/Step1BasicInfo.tsx` — name, email, role, department, type
- `steps/Step2PaymentMethod.tsx` — Fiat vs Crypto card selection
- `steps/Step3PaymentDetails.tsx` — **bank details step (Fiat only)**
  - Bank Name: `<Select>` dropdown with 18+ Nigerian banks
  - Account Number: text input (numeric only, 6–25 digits)
  - Account Name: read-only field, auto-fills after successful verification
  - "Continue" is disabled until the account is verified via `/api/accounts/validate`
- `steps/Step4Review.tsx` — full data summary before submit

### `src/components/features/team-management/employees.tsx`
- Added "Add Member" button to the employees header
- Wired empty state button to open the wizard

## How to test
1. Go to Team Management page
2. Click **Add Member** (top right of employee list)
3. Fill Step 1 → Choose **Fiat** in Step 2
4. Step 3 (Bank Details) appears — enter bank + account number → click **Verify**
5. Account Name auto-fills, Continue becomes enabled
6. Choose **Crypto** instead → Step 3 is skipped entirely → goes straight to Review
