### PR TITLE
feat: add network_passphrase validation to prevent cross-network tran…

### DIFF
--- a/src/server/services/blockchain.service.spec.ts
+++ b/src/server/services/blockchain.service.spec.ts
@@ -7,6 +7,7 @@ import {
   Operation,
   TransactionBuilder,
 } from "@stellar/stellar-sdk";
+import { TransactionXdr } from "./blockchain.service";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BlockchainService } from "./blockchain.service";
 
@@ -45,6 +46,17 @@ vi.mock("@stellar/stellar-sdk/rpc", () => {
     },
   };
 });
+
+vi.mock("../db", () => ({
+  db: {
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/server/db/schema", () => ({
+  signerAudits: {},
+}));
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -499,9 +511,36 @@ describe("BlockchainService", () => {
         }),
       ).rejects.toThrow(/Invalid inner transaction XDR/);
     });
+
+    it("should throw error when inner transaction network passphrase mismatches", async () => {
+      const mainnetInner: TransactionXdr = {
+        xdr: "AAAA...",
+        hash: "hash",
+        networkPassphrase: Networks.PUBLIC,
+      };
+
+      await expect(
+        service.buildFeeBumpXdr({
+          innerTxXdr: mainnetInner,
+          feeSourceSecret: TEST_SECRET,
+        }),
+      ).rejects.toThrow(/Cross-network transaction detected/);
+    });
   });
 
   describe("signTransaction", () => {
+    it("should throw error when network passphrase mismatches service configuration", async () => {
+      const mainnetInput: TransactionXdr = {
+        xdr: "AAAA...",
+        hash: "hash",
+        networkPassphrase: Networks.PUBLIC, // Service is configured for testnet in beforeEach
+      };
+
+      expect(() => service.signTransaction(mainnetInput, TEST_SECRET)).toThrow(
+        /Cross-network transaction detected/,
+      );
+    });
+
     it("should add a signature to an unsigned transaction", async () => {
       mockRpcServer.getAccount.mockResolvedValue(mockAccount(TEST_PUBLIC_KEY));
 
@@ -546,6 +585,18 @@ describe("BlockchainService", () => {
       expect(sim.transactionXdr).toBe(txXdr);
     });
 
+    it("should throw error when network passphrase mismatches", async () => {
+      const mainnetInput: TransactionXdr = {
+        xdr: "AAAA...",
+        hash: "hash",
+        networkPassphrase: Networks.PUBLIC,
+      };
+
+      await expect(service.simulateTransaction(mainnetInput)).rejects.toThrow(
+        /Cross-network transaction detected/,
+      );
+    });
+
     it("should throw when simulation returns an error", async () => {
       mockRpcServer.getAccount.mockResolvedValue(mockAccount(TEST_PUBLIC_KEY));
 
@@ -585,6 +636,18 @@ describe("BlockchainService", () => {
       const result = await service.prepareTransaction(txXdr);
       expect(result).toBe("prepared-xdr-string");
     });
+
+    it("should throw error when network passphrase mismatches", async () => {
+      const mainnetInput: TransactionXdr = {
+        xdr: "AAAA...",
+        hash: "hash",
+        networkPassphrase: Networks.PUBLIC,
+      };
+
+      await expect(service.prepareTransaction(mainnetInput)).rejects.toThrow(
+        /Cross-network transaction detected/,
+      );
+    });
   });
 
   describe("submitTransaction", () => {
@@ -620,6 +683,18 @@ describe("BlockchainService", () => {
       expect(result.status).toBe("SUCCESS");
       expect(result.ledger).toBe(100);
       expect(result.resultXdr).toBe("result-xdr-base64");
+    });
+
+    it("should throw error when network passphrase mismatches", async () => {
+      const mainnetInput: TransactionXdr = {
+        xdr: "AAAA...",
+        hash: "hash",
+        networkPassphrase: Networks.PUBLIC,
+      };
+
+      await expect(service.submitTransaction(mainnetInput)).rejects.toThrow(
+        /Cross-network transaction detected/,
+      );
     });
 
     it("should throw when sendTransaction is not PENDING", async () => {

--- a/src/server/services/blockchain.service.ts
+++ b/src/server/services/blockchain.service.ts
@@ -1,7 +1,4 @@
-import {
-  EnvServiceDiscovery,
-  ServiceDiscovery,
-} from "@/server/utils/service-discovery";
+import { db } from "../db";
 import {
   Address,
   Asset,
@@ -19,15 +16,31 @@ import {
 } from "@stellar/stellar-sdk";
 import { Api, Server as RpcServer } from "@stellar/stellar-sdk/rpc";
 import { Logger } from "./logger.service";
-import { ServiceDiscovery, EnvServiceDiscovery } from "@/server/utils/service-discovery";
 import {
-  wrapBlockchainError,
-  AccountNotFoundError,
-  InsufficientFundsError,
+  EnvServiceDiscovery,
+  ServiceDiscovery,
+} from "@/server/utils/service-discovery";
+import { signerAudits } from "@/server/db/schema";
+import {
   SimulationFailedError,
   TransactionRejectedError,
-  BlockchainError,
+  wrapBlockchainError,
 } from "@/server/utils/errors/blockchain-error";
+
+export interface GetContractEventsParams {
+  contractId?: string;
+  topics?: string[][];
+  fromLedger?: number;
+  limit?: number;
+}
+
+export interface ContractEvent {
+  id: string;
+  ledger: number;
+  contractId: string;
+  topics: any[];
+  value: any;
+}
 
 type NetworkName = "testnet" | "mainnet" | "futurenet";
 
@@ -267,7 +280,18 @@ export class BlockchainService {
     };
   }
 
-  signTransaction(xdrEnvelope: string, signerSecret: string): string {
+  private validateNetwork(passphrase?: string): void {
+    if (passphrase && passphrase !== this.networkConfig.networkPassphrase) {
+      throw new Error(
+        `Cross-network transaction detected: envelope is for "${passphrase}" but service is configured for "${this.networkConfig.networkPassphrase}"`,
+      );
+    }
+  }
+
+  signTransaction(input: string | TransactionXdr, signerSecret: string): string {
+    const xdrEnvelope = typeof input === "string" ? input : input.xdr;
+    this.validateNetwork(typeof input === "string" ? undefined : input.networkPassphrase);
+
     const tx = TransactionBuilder.fromXDR(
       xdrEnvelope,
       this.networkConfig.networkPassphrase,
@@ -292,7 +316,10 @@ export class BlockchainService {
     return tx.toXDR();
   }
 
-  async simulateTransaction(txXdr: string): Promise<SimulationResult> {
+  async simulateTransaction(input: string | TransactionXdr): Promise<SimulationResult> {
+    const txXdr = typeof input === "string" ? input : input.xdr;
+    this.validateNetwork(typeof input === "string" ? undefined : input.networkPassphrase);
+
     const tx = TransactionBuilder.fromXDR(
       txXdr,
       this.networkConfig.networkPassphrase,
@@ -324,7 +351,10 @@ export class BlockchainService {
     };
   }
 
-  async prepareTransaction(txXdr: string): Promise<string> {
+  async prepareTransaction(input: string | TransactionXdr): Promise<string> {
+    const txXdr = typeof input === "string" ? input : input.xdr;
+    this.validateNetwork(typeof input === "string" ? undefined : input.networkPassphrase);
+
     const tx = TransactionBuilder.fromXDR(
       txXdr,
       this.networkConfig.networkPassphrase,
@@ -334,7 +364,10 @@ export class BlockchainService {
     return prepared.toXDR();
   }
 
-  async submitTransaction(signedXdr: string): Promise<SubmissionResult> {
+  async submitTransaction(input: string | TransactionXdr): Promise<SubmissionResult> {
+    const signedXdr = typeof input === "string" ? input : input.xdr;
+    this.validateNetwork(typeof input === "string" ? undefined : input.networkPassphrase);
+
     const tx = TransactionBuilder.fromXDR(
       signedXdr,
       this.networkConfig.networkPassphrase,
@@ -405,16 +438,19 @@ export class BlockchainService {
   }
 
   async buildFeeBumpXdr(params: {
-    innerTxXdr: string;
+    innerTxXdr: string | TransactionXdr;
     feeSourceSecret: string;
     baseFee?: number | string;
   }): Promise<TransactionXdr> {
     const feeSourceKeypair = Keypair.fromSecret(params.feeSourceSecret);
+    
+    const innerXdr = typeof params.innerTxXdr === "string" ? params.innerTxXdr : params.innerTxXdr.xdr;
+    this.validateNetwork(typeof params.innerTxXdr === "string" ? undefined : params.innerTxXdr.networkPassphrase);
 
     let innerTx: Transaction | FeeBumpTransaction;
     try {
       innerTx = TransactionBuilder.fromXDR(
-        params.innerTxXdr,
+        innerXdr,
         this.networkConfig.networkPassphrase,
       );
     } catch (error) {


### PR DESCRIPTION
Closes #320

Summary: This PR introduces a strict network validation layer in BlockchainService. It prevents the accidental processing of transactions built for a different network (e.g., submitting a Testnet XDR to a Mainnet-configured service), which protects against permanent loss of funds and ledger state corruption.

Key Changes:

Validation Logic: Added a private validateNetwork helper that checks the networkPassphrase of an incoming TransactionXdr against the service's internal configuration.
Enhanced API: Updated signTransaction, simulateTransaction, prepareTransaction, submitTransaction, and buildFeeBumpXdr to accept the TransactionXdr interface.
Fail-Fast Mechanism: The service now throws a descriptive Error immediately if a network mismatch is detected, stopping the process before any signing or network calls occur.
Reliability: Added mocks for the audit database in the test suite and expanded test cases to verify rejection logic across all entry points.